### PR TITLE
[Redis] Rename client input/output buffer metrics

### DIFF
--- a/metricbeat/module/redis/info/data.go
+++ b/metricbeat/module/redis/info/data.go
@@ -26,10 +26,10 @@ import (
 var (
 	schema = s.Schema{
 		"clients": s.Object{
-			"connected":           c.Int("connected_clients"),
-			"longest_output_list": c.Int("client_longest_output_list"),
-			"biggest_input_buf":   c.Int("client_biggest_input_buf"),
-			"blocked":             c.Int("blocked_clients"),
+			"connected":         c.Int("connected_clients"),
+			"max_output_buffer": c.Int("client_recent_max_output_buffer"),
+			"max_input_buffer":  c.Int("client_recent_max_input_buffer"),
+			"blocked":           c.Int("blocked_clients"),
 		},
 		"cluster": s.Object{
 			"enabled": c.Bool("cluster_enabled"),


### PR DESCRIPTION
Hi,

In the upcoming Redis 5.0 release they changed client input/output buffer metrics: https://github.com/antirez/redis/commit/be88c0b16a53f5763d8fc1ae683f99ee39b0d68e. This PR is to reflect these changes.

Important:
- merge only after 5.0 is released
- contains breaking changes for metrics names (subject for discussion)